### PR TITLE
Don't add default values to list of variables + some QA

### DIFF
--- a/templater.sh
+++ b/templater.sh
@@ -122,7 +122,7 @@ var_value() {
 replaces=""
 
 # Reads default values defined as {{VAR=value}} and delete those lines
-# There are evaluated, so you can do {{PATH=$HOME}} or {{PATH=`pwd`}}
+# These are evaluated, so you can do {{PATH=$HOME}} or {{PATH=`pwd`}}
 # You can even reference variables defined in the template before
 defaults=$(grep -oE '^\{\{[A-Za-z0-9_]+=.+\}\}' "${template}" | sed -e 's/^{{//' -e 's/}}$//')
 

--- a/templater.sh
+++ b/templater.sh
@@ -137,8 +137,6 @@ for default in $defaults; do
 
     # remove define line
     replaces="-e '/^{{$var=/d' $replaces"
-    vars="$vars
-$current"
 done
 
 vars=$(echo $vars | sort | uniq)

--- a/templater.sh
+++ b/templater.sh
@@ -35,7 +35,7 @@ config_file="<none>"
 print_only="false"
 silent="false"
 
-usage="${PROGNAME} [-h] [-d] [-f] [-s] -- 
+usage="${PROGNAME} [-h] [-d] [-f] [-s] --
 
 where:
     -h, --help
@@ -48,13 +48,13 @@ where:
         Don't print warning messages (for example if no variables are found)
 
 examples:
-    VAR1=Something VAR2=1.2.3 ${PROGNAME} test.txt 
+    VAR1=Something VAR2=1.2.3 ${PROGNAME} test.txt
     ${PROGNAME} test.txt -f my-variables.txt
     ${PROGNAME} test.txt -f my-variables.txt > new-test.txt"
 
 if [ $# -eq 0 ]; then
   echo "$usage"
-  exit 1    
+  exit 1
 fi
 
 if [[ ! -f "${1}" ]]; then
@@ -72,7 +72,7 @@ if [ "$#" -ne 0 ]; then
         -h|--help)
             echo "$usage"
             exit 0
-            ;;        
+            ;;
         -p|--print)
             print_only="true"
             ;;
@@ -108,12 +108,12 @@ fi
 if [ "${config_file}" != "<none>" ]; then
     if [[ ! -f "${config_file}" ]]; then
       echo "The file ${config_file} does not exists" >&2
-      echo "$usage"      
+      echo "$usage"
       exit 1
     fi
 
     source "${config_file}"
-fi    
+fi
 
 var_value() {
     eval echo \$$1
@@ -153,7 +153,7 @@ fi
 
 # Replace all {{VAR}} by $VAR value
 for var in $vars; do
-    value=$(var_value $var | sed -e "s;\&;\\\&;g" -e "s;\ ;\\\ ;g") # '&' and <space> is escaped 
+    value=$(var_value $var | sed -e "s;\&;\\\&;g" -e "s;\ ;\\\ ;g") # '&' and <space> is escaped
     if [[ -z "$value" ]]; then
         if [ $silent == "false" ]; then
             echo "Warning: $var is not defined and no default is set, replacing by empty" >&2
@@ -162,7 +162,7 @@ for var in $vars; do
 
     # Escape slashes
     value=$(echo "$value" | sed 's/\//\\\//g');
-    replaces="-e 's/{{$var}}/${value}/g' $replaces"    
+    replaces="-e 's/{{$var}}/${value}/g' $replaces"
 done
 
 escaped_template_path=$(echo $template | sed 's/ /\\ /g')

--- a/templater.sh
+++ b/templater.sh
@@ -128,7 +128,7 @@ defaults=$(grep -oE '^\{\{[A-Za-z0-9_]+=.+\}\}' "${template}" | sed -e 's/^{{//'
 
 for default in $defaults; do
     var=$(echo "$default" | grep -oE "^[A-Za-z0-9_]+")
-    current=`var_value $var`
+    current=$(var_value $var)
 
     # Replace only if var is not set
     if [[ -z "$current" ]]; then
@@ -145,7 +145,7 @@ vars=$(echo $vars | sort | uniq)
 
 if [[ "$print_only" == "true" ]]; then
     for var in $vars; do
-        value=`var_value $var`
+        value=$(var_value $var)
         echo "$var = $value"
     done
     exit 0


### PR DESCRIPTION
When using default values, the script printed a warning for each default value: "... is not defined and no default is set, replacing by empty". Also when using the -p flag, you can see each default value as a variable with no value.

The cause is a line where each default value is added to the list of variables. This makes no sense to me, so I guess it's a bug. In this PR I removed that and indeed that gets rid of the warning. If there is any reason for that line that I missed, please inform me.

I also included some other small QA changes that I think make sense: fixed a typo, removed trailing whitespace and usage of $() instead of backticks.

Thanks for the great script! Perfect to use in a lean Docker container for some simple templating. Looking forward to your response.